### PR TITLE
add version field in manifest.json

### DIFF
--- a/custom_components/aligenie/manifest.json
+++ b/custom_components/aligenie/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": [],
   "codeowners": [
     "@dylan"
-  ]
+  ],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
The version key is required from Home Assistant version 2021.6